### PR TITLE
File based flavor cache and support for invoicing for V100

### DIFF
--- a/etc/flavors_cache.json
+++ b/etc/flavors_cache.json
@@ -1,0 +1,338 @@
+[
+    {
+        "id": 236,
+        "name": "cpu-a.1",
+        "vcpus": 1,
+        "memory": 2048,
+        "storage": 20
+    },
+    {
+        "id": 239,
+        "name": "cpu-a.2",
+        "vcpus": 2,
+        "memory": 4096,
+        "storage": 20
+    },
+    {
+        "id": 242,
+        "name": "cpu-a.4",
+        "vcpus": 4,
+        "memory": 8192,
+        "storage": 20
+    },
+    {
+        "id": 245,
+        "name": "cpu-a.8",
+        "vcpus": 8,
+        "memory": 16384,
+        "storage": 20
+    },
+    {
+        "id": 248,
+        "name": "cpu-a.16",
+        "vcpus": 16,
+        "memory": 32768,
+        "storage": 20
+    },
+    {
+        "id": 251,
+        "name": "mem-a.1",
+        "vcpus": 1,
+        "memory": 8192,
+        "storage": 20
+    },
+    {
+        "id": 254,
+        "name": "mem-a.2",
+        "vcpus": 2,
+        "memory": 16384,
+        "storage": 20
+    },
+    {
+        "id": 257,
+        "name": "mem-a.4",
+        "vcpus": 4,
+        "memory": 32768,
+        "storage": 20
+    },
+    {
+        "id": 260,
+        "name": "mem-a.8",
+        "vcpus": 8,
+        "memory": 65536,
+        "storage": 20
+    },
+    {
+        "id": 263,
+        "name": "mem-a.16",
+        "vcpus": 16,
+        "memory": 131072,
+        "storage": 20
+    },
+    {
+        "id": 266,
+        "name": "gpu-a100.1",
+        "vcpus": 12,
+        "memory": 98304,
+        "storage": 20
+    },
+    {
+        "id": 269,
+        "name": "gpu-a100.2",
+        "vcpus": 24,
+        "memory": 196608,
+        "storage": 20
+    },
+    {
+        "id": 272,
+        "name": "gpu-a100.4",
+        "vcpus": 48,
+        "memory": 393216,
+        "storage": 20
+    },
+    {
+        "id": 275,
+        "name": "cpu-su.1",
+        "vcpus": 1,
+        "memory": 4096,
+        "storage": 20
+    },
+    {
+        "id": 278,
+        "name": "cpu-su.2",
+        "vcpus": 2,
+        "memory": 8192,
+        "storage": 20
+    },
+    {
+        "id": 281,
+        "name": "cpu-su.4",
+        "vcpus": 4,
+        "memory": 16384,
+        "storage": 20
+    },
+    {
+        "id": 284,
+        "name": "cpu-su.8",
+        "vcpus": 8,
+        "memory": 32768,
+        "storage": 20
+    },
+    {
+        "id": 287,
+        "name": "cpu-su.16",
+        "vcpus": 16,
+        "memory": 65536,
+        "storage": 20
+    },
+    {
+        "id": 290,
+        "name": "mem-su.1",
+        "vcpus": 1,
+        "memory": 8192,
+        "storage": 20
+    },
+    {
+        "id": 293,
+        "name": "mem-su.2",
+        "vcpus": 2,
+        "memory": 16384,
+        "storage": 20
+    },
+    {
+        "id": 296,
+        "name": "mem-su.4",
+        "vcpus": 4,
+        "memory": 32768,
+        "storage": 20
+    },
+    {
+        "id": 299,
+        "name": "mem-su.8",
+        "vcpus": 8,
+        "memory": 65536,
+        "storage": 20
+    },
+    {
+        "id": 302,
+        "name": "mem-su.16",
+        "vcpus": 16,
+        "memory": 131072,
+        "storage": 20
+    },
+    {
+        "id": 305,
+        "name": "gpu-su-a100.1",
+        "vcpus": 24,
+        "memory": 97280,
+        "storage": 20
+    },
+    {
+        "id": 308,
+        "name": "gpu-su-a100.2",
+        "vcpus": 48,
+        "memory": 194560,
+        "storage": 20
+    },
+    {
+        "id": 311,
+        "name": "gpu-su-v100.1",
+        "vcpus": 24,
+        "memory": 98304,
+        "storage": 20
+    },
+    {
+        "id": 314,
+        "name": "gpu-su-v100.1m",
+        "vcpus": 48,
+        "memory": 196608,
+        "storage": 20
+    },
+    {
+        "id": 317,
+        "name": "ocp-large",
+        "vcpus": 48,
+        "memory": 196608,
+        "storage": 20
+    },
+    {
+        "id": 5,
+        "name": "Unknown",
+        "vcpus": 1,
+        "memory": 2048,
+        "storage": 10
+    },
+    {
+        "id": 11,
+        "name": "Unknown",
+        "vcpus": 4,
+        "memory": 8192,
+        "storage": 10
+    },
+    {
+        "id": 191,
+        "name": "gpu-v100.1",
+        "vcpus": 12,
+        "memory": 98304,
+        "storage": 10
+    },
+    {
+        "id": 126,
+        "name": "cpu-a.2",
+        "vcpus": 2,
+        "memory": 4096,
+        "storage": 20
+    },
+    {
+        "id": 141,
+        "name": "mem-a.2",
+        "vcpus": 2,
+        "memory": 16384,
+        "storage": 20
+    },
+    {
+        "id": 153,
+        "name": "cpu-a.1",
+        "vcpus": 1,
+        "memory": 2048,
+        "storage": 20
+    },
+    {
+        "id": 156,
+        "name": "cpu-a.4",
+        "vcpus": 4,
+        "memory": 8192,
+        "storage": 20
+    },
+    {
+        "id": 159,
+        "name": "cpu-a.8",
+        "vcpus": 8,
+        "memory": 16384,
+        "storage": 20
+    },
+    {
+        "id": 162,
+        "name": "cpu-a.16",
+        "vcpus": 16,
+        "memory": 32768,
+        "storage": 20
+    },
+    {
+        "id": 165,
+        "name": "mem-a.1",
+        "vcpus": 1,
+        "memory": 8192,
+        "storage": 20
+    },
+    {
+        "id": 168,
+        "name": "mem-a.4",
+        "vcpus": 4,
+        "memory": 32768,
+        "storage": 20
+    },
+    {
+        "id": 171,
+        "name": "mem-a.8",
+        "vcpus": 8,
+        "memory": 65536,
+        "storage": 20
+    },
+    {
+        "id": 174,
+        "name": "mem-a.16",
+        "vcpus": 16,
+        "memory": 131072,
+        "storage": 20
+    },
+    {
+        "id": 183,
+        "name": "gpu-a100.1",
+        "vcpus": 12,
+        "memory": 98304,
+        "storage": 20
+    },
+    {
+        "id": 186,
+        "name": "gpu-a100.2",
+        "vcpus": 24,
+        "memory": 196608,
+        "storage": 20
+    },
+    {
+        "id": 189,
+        "name": "gpu-a100.4",
+        "vcpus": 48,
+        "memory": 393216,
+        "storage": 20
+    },
+    {
+        "id": 2,
+        "name": "Unknown",
+        "vcpus": 1,
+        "memory": 1024,
+        "storage": 10
+    },
+    {
+        "id": 53,
+        "name": "Unknown",
+        "vcpus": 8,
+        "memory": 16384,
+        "storage": 25
+    },
+    {
+        "id": 47,
+        "name": "Unknown",
+        "vcpus": 2,
+        "memory": 4096,
+        "storage": 25
+    },
+    {
+        "id": 8,
+        "name": "Unknown",
+        "vcpus": 2,
+        "memory": 4096,
+        "storage": 10
+    }
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+dataclasses-json
 mysql-connector-python

--- a/src/openstack_billing_db/billing.py
+++ b/src/openstack_billing_db/billing.py
@@ -19,6 +19,7 @@ class ProjectInvoice(object):
 
     cpu_su_hours: int = 0
     gpu_a100_su_hours: int = 0
+    gpu_v100_su_hours: int = 0
 
     institution_specific_code: str = "N/A"
 
@@ -46,9 +47,10 @@ def collect_invoice_data_from_openstack(database, billing_start, billing_end):
 
                     if i.service_unit_type == "CPU":
                         invoice.cpu_su_hours += cost
-                    elif i.service_unit_type == "GPU":
-                        # There's only a A100 flavor at the moment.
+                    elif i.service_unit_type == "GPU A100":
                         invoice.gpu_a100_su_hours += cost
+                    elif i.service_unit_type == "GPU V100":
+                        invoice.gpu_v100_su_hours += cost
                 except Exception:
                     raise Exception("Invalid flavor.")
 
@@ -113,7 +115,7 @@ def write(invoices, output):
         )
 
         for invoice in invoices:
-            for invoice_type in ['cpu', 'gpu_a100']:
+            for invoice_type in ['cpu', 'gpu_a100', 'gpu_v100']:
                 # Each project gets two rows, one for CPU and one for GPU
                 hours = invoice.__getattribute__(f"{invoice_type}_su_hours")
                 if hours > 0:
@@ -128,7 +130,7 @@ def write(invoices, output):
                             invoice.institution,
                             invoice.institution_specific_code,
                             hours,
-                            f"{invoice_type.replace('_', '').upper()}",
+                            f"{invoice_type.replace('_', ' ').upper()}",
                             "",  # Rate
                             "",  # Cost
                         ]

--- a/src/openstack_billing_db/main.py
+++ b/src/openstack_billing_db/main.py
@@ -33,6 +33,11 @@ def main():
               "Used for populating project names and PIs.")
     )
     parser.add_argument(
+        "--flavors-cache-file",
+        default=None,
+        help="Path to file to cache previously encountered flavors."
+    )
+    parser.add_argument(
         "output",
         help="Output path for invoice in CSV format."
     )
@@ -43,7 +48,8 @@ def main():
         args.start,
         args.end,
         args.output,
-        coldfront_data_file=args.coldfront_data_file
+        coldfront_data_file=args.coldfront_data_file,
+        flavors_cache_file=args.flavors_cache_file,
     )
 
 

--- a/src/openstack_billing_db/model.py
+++ b/src/openstack_billing_db/model.py
@@ -2,12 +2,15 @@ from abc import ABC, abstractmethod
 import math
 import datetime
 from dataclasses import dataclass
+from dataclasses_json import dataclass_json
 
 import mysql.connector
 
 
+@dataclass_json()
 @dataclass()
 class Flavor(object):
+    id: int
     name: str
     vcpus: int
     memory: int
@@ -103,7 +106,7 @@ class BaseDatabase(object):
 
 class Database(BaseDatabase):
 
-    def __init__(self):
+    def __init__(self, initial_flavors=None):
         self.db_nova = mysql.connector.connect(
             host="127.0.0.1",
             database="nova",
@@ -118,11 +121,18 @@ class Database(BaseDatabase):
             password="root",
         )
 
-        self.flavors = self.get_flavors()
-        self._projects = self.get_projects()
+        self.flavors = dict()
+        if initial_flavors:
+            self.flavors.update({f.id: f for f in list(initial_flavors)})
+        self.flavors.update(self.get_flavors())
+
+        self._projects = None
 
     @property
     def projects(self) -> list[Project]:
+        if not self._projects:
+            self._projects = self.get_projects()
+
         return self._projects
 
     def get_flavors(self) -> dict[Flavor]:
@@ -134,21 +144,11 @@ class Database(BaseDatabase):
 
         flavors = dict()
         for flavor in result:
-            flavors[flavor["id"]] = Flavor(name=flavor["name"],
+            flavors[flavor["id"]] = Flavor(id=flavor["id"],
+                                           name=flavor["name"],
                                            vcpus=flavor["vcpus"],
                                            memory=flavor["memory_mb"],
                                            storage=flavor["root_gb"])
-
-        # Add flavors that don't exist in the database anymore
-        flavors[5] = Flavor(
-            name="Unknown", vcpus=1, memory=2048, storage=10
-        )
-        flavors[11] = Flavor(
-            name="Unknown", vcpus=4, memory=8192, storage=10
-        )
-        flavors[191] = Flavor(
-            name="gpu-v100.1", vcpus=12, memory=98304, storage=10
-        )
         return flavors
 
     def get_events(self, instance_uuid) -> list[InstanceEvent]:

--- a/src/openstack_billing_db/model.py
+++ b/src/openstack_billing_db/model.py
@@ -25,6 +25,11 @@ class Flavor(object):
                 self.memory / 4096,
             ))
         else:
+            # The flavor for 2 SUs of V100 is inconsistent with previous
+            # naming scheme.
+            if self.name == "gpu-su-v100.1m":
+                return 2
+
             split = self.name.split(".")
             return int(split[-1])
 
@@ -32,8 +37,13 @@ class Flavor(object):
     def service_unit_type(self):
         if "gpu" not in self.name:
             return "CPU"
+        elif "a100" in self.name:
+            return "GPU A100"
+        elif "v100" in self.name:
+            return "GPU V100"
         else:
-            return "GPU"
+            # New GPU type that we need to take into account.
+            raise Exception()
 
 
 @dataclass()

--- a/src/openstack_billing_db/tests/unit/test_instance.py
+++ b/src/openstack_billing_db/tests/unit/test_instance.py
@@ -4,7 +4,8 @@ from datetime import datetime, timedelta
 from openstack_billing_db.model import Instance, InstanceEvent, Flavor
 
 FLAVORS = {
-    1: Flavor(name="TestFlavor",
+    1: Flavor(id=1,
+              name="TestFlavor",
               vcpus=1,
               memory=4096,
               storage=10)


### PR DESCRIPTION
When a flavor is deleted, it is also deleted from the database. This leads to instances with no flavor information associated to them. Some flavor information can be extracted from the instance information in the database, but not the name.

This change implements a file based flavor cache that saves the flavors previously encountered into a JSON file that is then loaded to provide this information unavailable from the database.

Additionally, this change also adds support for GPU V100, and reworks the code to distinguish which GPU flavor is being used and how many SUs. 