### PR TITLE
Add CLI argument for using Invoice Month instead of Interval

### DIFF
--- a/src/openstack_billing_db/billing.py
+++ b/src/openstack_billing_db/billing.py
@@ -143,7 +143,7 @@ def merge_coldfront_data(invoices, coldfront_data_file):
             continue
 
 
-def write(invoices, output):
+def write(invoices, output, invoice_month=None):
     with open(output, 'w', newline='') as f:
         csv_invoice_writer = csv.writer(
             f, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL
@@ -151,7 +151,7 @@ def write(invoices, output):
         # Write Headers
         csv_invoice_writer.writerow(
             [
-                "Interval",
+                "Invoice Month" if invoice_month else "Interval",
                 "Project - Allocation",
                 "Project - Allocation ID",
                 "Manager (PI)",
@@ -174,9 +174,10 @@ def write(invoices, output):
                 su_name = invoice.rates.__getattribute__(f"{invoice_type}_su_name")
                 cost = invoice.__getattribute__(f"{invoice_type}_su_cost")
                 if hours > 0:
+
                     csv_invoice_writer.writerow(
                         [
-                            invoice.invoice_interval,
+                            invoice_month if invoice_month else invoice.invoice_interval,
                             invoice.project_name,
                             invoice.project_id,
                             invoice.pi,
@@ -193,7 +194,8 @@ def write(invoices, output):
 
 
 def generate_billing(start, end, output, rates,
-                     coldfront_data_file=None, flavors_cache_file=None):
+                     coldfront_data_file=None, flavors_cache_file=None,
+                     invoice_month=None):
     # Flavors are occasionally deleted leaving no reference in the
     # database.
     flavors_cache = None
@@ -211,4 +213,4 @@ def generate_billing(start, end, output, rates,
     invoices = collect_invoice_data_from_openstack(database, start, end, rates)
     if coldfront_data_file:
         merge_coldfront_data(invoices, coldfront_data_file)
-    write(invoices, output)
+    write(invoices, output, invoice_month)

--- a/src/openstack_billing_db/main.py
+++ b/src/openstack_billing_db/main.py
@@ -28,6 +28,11 @@ def main():
         type=parse_time_argument
     )
     parser.add_argument(
+        "--invoice-month",
+        default=None,
+        help="Use the first column for Invoice Month, rather than Interval."
+    )
+    parser.add_argument(
         "--coldfront-data-file",
         default=None,
         help=("Path to JSON Output of ColdFront's /api/allocations."
@@ -96,7 +101,8 @@ def main():
         args.output,
         rates,
         coldfront_data_file=args.coldfront_data_file,
-        flavors_cache_file=args.flavors_cache_file
+        flavors_cache_file=args.flavors_cache_file,
+        invoice_month=args.invoice_month,
     )
 
 


### PR DESCRIPTION
Prior to this change, the first column and column header would refer to the date range used for generating the invoices, rather than month.