### PR TITLE
Filter instances deleted before start date

### DIFF
--- a/src/openstack_billing_db/billing.py
+++ b/src/openstack_billing_db/billing.py
@@ -197,7 +197,7 @@ def generate_billing(start, end, output, rates,
                      coldfront_data_file=None,
                      invoice_month=None):
 
-    database = model.Database()
+    database = model.Database(start=start)
 
     invoices = collect_invoice_data_from_openstack(database, start, end, rates)
     if coldfront_data_file:

--- a/src/openstack_billing_db/model.py
+++ b/src/openstack_billing_db/model.py
@@ -170,13 +170,14 @@ class BaseDatabase(object):
 
 class Database(BaseDatabase):
 
-    def __init__(self):
+    def __init__(self, start):
         self.db_nova = mysql.connector.connect(
             host="127.0.0.1",
             database="nova",
             user="root",
             password="root",
         )
+        self.start = start
 
         self._projects = None
 
@@ -216,7 +217,10 @@ class Database(BaseDatabase):
                 pci_requests
             from instances
             left join instance_extra on instances.uuid = instance_extra.instance_uuid
-            where instances.project_id = "{project}"
+            where
+                instances.project_id = "{project}"
+                and (instances.deleted_at > "{self.start.isoformat()}"
+                    or instances.deleted = 0)
         """)
 
         for instance in cursor.fetchall():


### PR DESCRIPTION
Depends on #30 (only consider last commit)

---

Filter instances deleted before start date
Implements a WHERE clause in the SQL query for instances that
filters out all instances that were deleted before the start
date of this billing cycle.

This brings several advantages
- Makes the query faster as it reduces the number of instances to
  process the events for.
- Improves robustness of the script, since we don't need to deal
  with possible edge cases from VMs before the start of the
  invoicing window. (E.g. VMs that ops team was testing resize on.)