### PR TITLE
Use SQLite3 instead of MariaDB

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 boto3
 dataclasses-json
-mysql-connector-python

--- a/src/openstack_billing_db/billing.py
+++ b/src/openstack_billing_db/billing.py
@@ -200,9 +200,10 @@ def write(invoices, output, invoice_month=None):
 def generate_billing(start, end, output, rates,
                      coldfront_data_file=None,
                      invoice_month=None,
-                     upload_to_s3=False):
+                     upload_to_s3=False,
+                     sql_dump_file=None):
 
-    database = model.Database(start=start)
+    database = model.Database(start, sql_dump_file)
 
     invoices = collect_invoice_data_from_openstack(database, start, end, rates)
     if coldfront_data_file:

--- a/src/openstack_billing_db/main.py
+++ b/src/openstack_billing_db/main.py
@@ -39,6 +39,12 @@ def main():
               "Used for populating project names and PIs.")
     )
     parser.add_argument(
+        "--sql-dump-file",
+        required=True,
+        help=("Path to SQL Dump of Nova DB. Must have been converted to SQLite3"
+              "compatible format using https://github.com/dumblob/mysql2sqlite.")
+    )
+    parser.add_argument(
         "--rate-cpu-su",
         default=0,
         type=Decimal,
@@ -110,6 +116,7 @@ def main():
         coldfront_data_file=args.coldfront_data_file,
         invoice_month=args.invoice_month,
         upload_to_s3=args.upload_to_s3,
+        sql_dump_file=args.sql_dump_file,
     )
 
 


### PR DESCRIPTION
This is part of a series of work to reduce the amount of setup
required for running the script and remove as many external
dependencies as possible.

By removing the dependency on MariaDB, this workflow can run in a
container without requiring a sidecar.

All the information that we need for invoicing is present in
three tables from one single database (instances, instance_{actions,extra})
which have a simple foreign key relationship, we're not relying
on any special features from MariaDB that are not present in SQLite.

It is not possible to import a `mysqldump` generated file into Sqlite
though, but there is a script of GitHub that performs the conversion
successfully. https://github.com/dumblob/mysql2sqlite

A follow-up patch will introduce a Dockerfile that includes the
binary and automatically does the conversion process.

- Introduces a `--sql-dump-file` argument. That file is opened and
  executed inside an in-memory sqlite3 database.
- File must have been previously converted using `mysql2sqlite`.
- Slight changes to syntax.
  - Distinct instead of unique()
  - sqlite3.Row as a row_factory instead of providing
    dictionary=True to the cursor.
- Additionally, I had to had a check to _clamp_time that ensures
  the type argument was not of type string, and converted it if so.
  I ran into an error that the provided argument (coming from the db)
  was of type string somehow.