### PR TITLE
Upload CSV to S3 on completion

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+boto3
 dataclasses-json
 mysql-connector-python

--- a/src/openstack_billing_db/billing.py
+++ b/src/openstack_billing_db/billing.py
@@ -210,6 +210,8 @@ def generate_billing(start, end, output, rates,
     write(invoices, output, invoice_month)
 
     if upload_to_s3:
+        s3_endpoint = os.getenv("S3_OUTPUT_ENDPOINT_URL",
+                                "https://s3.us-east-005.backblazeb2.com")
         s3_key_id = os.getenv("S3_OUTPUT_ACCESS_KEY_ID")
         s3_secret = os.getenv("S3_OUTPUT_SECRET_ACCESS_KEY")
 
@@ -221,7 +223,7 @@ def generate_billing(start, end, output, rates,
 
         s3 = boto3.client(
             "s3",
-            endpoint_url="https://s3.us-east-005.backblazeb2.com",
+            endpoint_url=s3_endpoint,
             aws_access_key_id=s3_key_id,
             aws_secret_access_key=s3_secret,
         )

--- a/src/openstack_billing_db/billing.py
+++ b/src/openstack_billing_db/billing.py
@@ -1,10 +1,14 @@
 import csv
+from datetime import datetime
 from dataclasses import dataclass
 from decimal import Decimal
 import json
 import math
+import os
 
 from openstack_billing_db import model
+
+import boto3
 
 
 @dataclass()
@@ -195,7 +199,8 @@ def write(invoices, output, invoice_month=None):
 
 def generate_billing(start, end, output, rates,
                      coldfront_data_file=None,
-                     invoice_month=None):
+                     invoice_month=None,
+                     upload_to_s3=False):
 
     database = model.Database()
 
@@ -203,3 +208,33 @@ def generate_billing(start, end, output, rates,
     if coldfront_data_file:
         merge_coldfront_data(invoices, coldfront_data_file)
     write(invoices, output, invoice_month)
+
+    if upload_to_s3:
+        s3_key_id = os.getenv("S3_OUTPUT_ACCESS_KEY_ID")
+        s3_secret = os.getenv("S3_OUTPUT_SECRET_ACCESS_KEY")
+
+        if not s3_key_id or not s3_secret:
+            raise Exception("Must provide S3_OUTPUT_ACCESS_KEY_ID and"
+                            " S3_OUTPUT_SECRET_ACCESS_KEY environment variables.")
+        if not invoice_month:
+            raise Exception("No invoice month specified. Required for S3 upload.")
+
+        s3 = boto3.client(
+            "s3",
+            endpoint_url="https://s3.us-east-005.backblazeb2.com",
+            aws_access_key_id=s3_key_id,
+            aws_secret_access_key=s3_secret,
+        )
+
+        primary_location = (
+            f"Invoices/{invoice_month}/"
+            f"Service Invoices/NERC OpenStack {invoice_month}.csv"
+        )
+        s3.upload_file(output, Bucket="nerc-invoicing", Key=primary_location)
+
+        timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
+        secondary_location = (
+            f"Invoices/{invoice_month}/"
+            f"Archive/NERC OpenStack {invoice_month} {timestamp}.csv"
+        )
+        s3.upload_file(output, Bucket="nerc-invoicing", Key=secondary_location)

--- a/src/openstack_billing_db/billing.py
+++ b/src/openstack_billing_db/billing.py
@@ -212,6 +212,7 @@ def generate_billing(start, end, output, rates,
     if upload_to_s3:
         s3_endpoint = os.getenv("S3_OUTPUT_ENDPOINT_URL",
                                 "https://s3.us-east-005.backblazeb2.com")
+        s3_bucket = os.getenv("S3_OUTPUT_BUCKET", "nerc-invoicing")
         s3_key_id = os.getenv("S3_OUTPUT_ACCESS_KEY_ID")
         s3_secret = os.getenv("S3_OUTPUT_SECRET_ACCESS_KEY")
 
@@ -232,11 +233,11 @@ def generate_billing(start, end, output, rates,
             f"Invoices/{invoice_month}/"
             f"Service Invoices/NERC OpenStack {invoice_month}.csv"
         )
-        s3.upload_file(output, Bucket="nerc-invoicing", Key=primary_location)
+        s3.upload_file(output, Bucket=s3_bucket, Key=primary_location)
 
         timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
         secondary_location = (
             f"Invoices/{invoice_month}/"
             f"Archive/NERC OpenStack {invoice_month} {timestamp}.csv"
         )
-        s3.upload_file(output, Bucket="nerc-invoicing", Key=secondary_location)
+        s3.upload_file(output, Bucket=s3_bucket, Key=secondary_location)

--- a/src/openstack_billing_db/main.py
+++ b/src/openstack_billing_db/main.py
@@ -78,7 +78,12 @@ def main():
         "--upload-to-s3",
         default=False,
         type=bool,
-        help="Upload to Backblaze B2 Bucket for MOC."
+        help=("Uploads the CSV result to S3 compatible storage."
+              " Must provide S3_OUTPUT_ACCESS_KEY_ID and"
+              " S3_OUTPUT_SECRET_ACCESS_KEY environment variables."
+              " Defaults to Backblaze and to nerc-invoicing bucket"
+              " but can be configured through S3_OUTPUT_BUCKET and"
+              " S3_OUTPUT_ENDPOINT_URL environment variables.")
     )
     parser.add_argument(
         "output",

--- a/src/openstack_billing_db/main.py
+++ b/src/openstack_billing_db/main.py
@@ -75,7 +75,14 @@ def main():
         help="Include stopped runtime for instances."
     )
     parser.add_argument(
+        "--upload-to-s3",
+        default=False,
+        type=bool,
+        help="Upload to Backblaze B2 Bucket for MOC."
+    )
+    parser.add_argument(
         "output",
+        default="/tmp/openstack_invoices.csv",
         help="Output path for invoice in CSV format."
     )
 
@@ -97,6 +104,7 @@ def main():
         rates,
         coldfront_data_file=args.coldfront_data_file,
         invoice_month=args.invoice_month,
+        upload_to_s3=args.upload_to_s3,
     )
 
 


### PR DESCRIPTION
Adds the option to upload the generated invoice to Backblaze S3 compatible storage. We're collecting our invoices in the Bucket `nerc-invoicing` under the account msd. (Backblaze doesn’t allow the concept of a shared bucket, but admins of the organization can log in under any user and access their buckets.)

Provide `--upload-to-s3 True` (defaults to false). It will upload two copies of the invoice using the below format (one for archiving and timestamped and one as a working copy)

```
/Invoices/<INVOICE_MONTH>/Service Invoices/<SERVICE> <INVOICE_MONTH>.csv
/Invoices/<INVOICE_MONTH>/Archive/<SERVICE> <INVOICE_MONTH> <TIMESTAMP>.csv
```

Where Timestamp is the time at generation using the ISO8601 format and without any special characters. See example below.

For example, for November 2023.

```
/Invoices/2023-11/Service Invoices/NERC OpenStack 2023-11.csv
/Invoices/2023-11/Service Invoices/NERC OpenShift 2023-11.csv
/Invoices/2023-11/Service Invoices/NERC Storage 2023-11.csv
/Invoices/2023-11/Archive/NERC OpenStack 2023-11 20231218T201706Z.csv
/Invoices/2023-11/Archive/NERC OpenShift 2023-11 20231218T201706Z.csv
/Invoices/2023-11/Archive/NERC Storage 2023-11 20231218T201706Z.csv
```

Tooling for OpenShift invoicing is already able to upload files using the above described conventions.