### PR TITLE
Add support for downloading and loading mysqldump from S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,55 @@ Simple billing solution for OpenStack that fetches the information from the
 database.
 
 ```bash
-usage: python -m openstack_billing_db.main [-h] --start START --end END
+python3 -m openstack_billing_db.main --help
+usage: python -m openstack_billing_db.main [-h] --start START --end END [--invoice-month INVOICE_MONTH]
+                                           [--coldfront-data-file COLDFRONT_DATA_FILE] [--sql-dump-file SQL_DUMP_FILE]
+                                           [--convert-sql-dump-file-to-sqlite CONVERT_SQL_DUMP_FILE_TO_SQLITE]
+                                           [--download-sql-dump-from-s3 DOWNLOAD_SQL_DUMP_FROM_S3] [--rate-cpu-su RATE_CPU_SU]
+                                           [--rate-gpu-a100-su RATE_GPU_A100_SU] [--rate-gpu-v100-su RATE_GPU_V100_SU]
+                                           [--rate-gpu-k80-su RATE_GPU_K80_SU] [--rate-gpu-a2-su RATE_GPU_A2_SU]
+                                           [--include-stopped-runtime INCLUDE_STOPPED_RUNTIME] [--upload-to-s3 UPLOAD_TO_S3]
+                                           output
 
 Simple OpenStack Invoicing from the Nova DB
 
+positional arguments:
+  output                Output path for invoice in CSV format.
+
 options:
-  -h, --help     show this help message and exit
-  --start START  Start of the invoicing period. (YYYY-MM-DD)
-  --end END      End of the invoicing period. (YYYY-MM-DD)
+  -h, --help            show this help message and exit
+  --start START         Start of the invoicing period. (YYYY-MM-DD)
+  --end END             End of the invoicing period. (YYYY-MM-DD)
+  --invoice-month INVOICE_MONTH
+                        Use the first column for Invoice Month, rather than Interval.
+  --coldfront-data-file COLDFRONT_DATA_FILE
+                        Path to JSON Output of ColdFront's /api/allocations.Used for populating project names and PIs.
+  --sql-dump-file SQL_DUMP_FILE
+                        Path to SQL Dump of Nova DB. Must have been converted to SQLite3compatible format using
+                        https://github.com/dumblob/mysql2sqlite.
+  --convert-sql-dump-file-to-sqlite CONVERT_SQL_DUMP_FILE_TO_SQLITE
+                        Automatically convert SQL dump to SQlite3 compatible format using
+                        https://github.com/dumblob/mysql2sqlite.
+  --download-sql-dump-from-s3 DOWNLOAD_SQL_DUMP_FROM_S3
+                        Downloads Nova DB Dump from S3. Must provide S3_INPUT_ACCESS_KEY_ID and S3_INPUT_SECRET_ACCESS_KEY
+                        environment variables. Defaults to Backblaze and to nerc-invoicing bucket but can be configured through
+                        S3_INPUT_BUCKET and S3_OUTPUT_ENDPOINT_URL environment variables. Automatically decompresses the file if
+                        gzipped.
+  --rate-cpu-su RATE_CPU_SU
+                        Rate of CPU SU/hr
+  --rate-gpu-a100-su RATE_GPU_A100_SU
+                        Rate of GPU A100 SU/hr
+  --rate-gpu-v100-su RATE_GPU_V100_SU
+                        Rate of GPU V100 SU/hr
+  --rate-gpu-k80-su RATE_GPU_K80_SU
+                        Rate of GPU K80 SU/hr
+  --rate-gpu-a2-su RATE_GPU_A2_SU
+                        Rate of GPU A2 SU/hr
+  --include-stopped-runtime INCLUDE_STOPPED_RUNTIME
+                        Include stopped runtime for instances.
+  --upload-to-s3 UPLOAD_TO_S3
+                        Uploads the CSV result to S3 compatible storage. Must provide S3_OUTPUT_ACCESS_KEY_ID and
+                        S3_OUTPUT_SECRET_ACCESS_KEY environment variables. Defaults to Backblaze and to nerc-invoicing bucket but
+                        can be configured through S3_OUTPUT_BUCKET and S3_OUTPUT_ENDPOINT_URL environment variables.
 
 ```

--- a/src/openstack_billing_db/fetch.py
+++ b/src/openstack_billing_db/fetch.py
@@ -1,0 +1,114 @@
+from datetime import datetime
+import logging
+import os
+import subprocess
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+
+def download_latest_dump_from_s3() -> str:
+    """Download the dump of the nova db from S3 storage.
+
+    Returns location of uncompressed, downloaded file.
+
+    NERC dumps are stored at S3 compatible storage located with endpoint
+    https://holecs.rc.fas.harvard.edu under the bucket nerc-osp-backups.
+
+    This storage is behind firewall, however it's accessible from
+    nerc-shift-0.
+
+    Here's an example query for the database dump of 2024-02-02.
+
+    $ aws --endpoint-url https://holecs.rc.fas.harvard.edu \
+        s3api list-objects --bucket nerc-osp-backups \
+        --prefix dbs/nerc-ctl-0/nova-20240202
+
+    {
+        "Contents": [
+            {
+                "Key": "dbs/nerc-ctl-0/nova-20240202000002.sql.gz",
+                "LastModified": "2024-02-02T05:00:36.823Z",
+                [omitted]
+                "Size": 15703324,
+                "StorageClass": "STANDARD",
+                "Owner": [omitted]
+            }
+        ]
+    }
+
+    """
+    s3_endpoint = os.getenv("S3_INPUT_ENDPOINT_URL",
+                            "https://holecs.rc.fas.harvard.edu")
+    s3_bucket = os.getenv("S3_INPUT_BUCKET", "nerc-osp-backups")
+    s3_key_id = os.getenv("S3_INPUT_ACCESS_KEY_ID")
+    s3_secret = os.getenv("S3_INPUT_SECRET_ACCESS_KEY")
+
+    if not s3_key_id or not s3_secret:
+        raise Exception("Must provide S3_INPUT_ACCESS_KEY_ID and"
+                        " S3_INPUT_SECRET_ACCESS_KEY environment variables.")
+
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=s3_endpoint,
+        aws_access_key_id=s3_key_id,
+        aws_secret_access_key=s3_secret,
+    )
+
+    today = datetime.today().strftime('%Y%m%d')
+    dumps = s3.list_objects_v2(Bucket=s3_bucket,
+                               Prefix=f"dbs/nerc-ctl-0/nova-{today}")
+
+    if len(dumps["Contents"]) == 0:
+        raise Exception(f"No database dumps found for {today}")
+
+    key = dumps["Contents"][0]["Key"]
+    filename = os.path.basename(key)
+    download_location = f"/tmp/{filename}"
+
+    logger.info(f"Downloading {key} to {download_location}.")
+    s3.download_file(s3_bucket, key, download_location)
+
+    logger.info("Download complete.")
+
+    path_without_ext, extension = os.path.splitext(download_location)
+    if extension == ".gz":
+        logger.info(f"Uncompressing {download_location}")
+        command = subprocess.run(["gzip", "-d", download_location])
+        if command.returncode != 0:
+            raise Exception(f"Error uncompressing {download_location}.")
+
+        # Uncompressing removes the .gz, so the file should be named
+        # same as path above, and the new extension should be .sql.
+        download_location = path_without_ext
+        logger.info(f"Uncompressed at {path_without_ext}.")
+
+    return download_location
+
+
+def convert_mysqldump_to_sqlite(path_to_dump) -> str:
+    """Converts mysqldump generated SQL file to SQLite compatible.
+
+    Requires mysql2sqlite binary, fetched from here
+    https://github.com/dumblob/mysql2sqlite.
+
+    Returns location of converted file.
+    """
+    path_without_ext, extension = os.path.splitext(path_to_dump)
+
+    if not extension == ".sql":
+        raise Exception("Unsupported file extension for conversion to SQLite.")
+
+    logger.info("Converting MySQL dump to SQLite compatible.")
+
+    destination_path = f"/tmp/{os.path.basename(path_without_ext)}_converted.sql"
+    with open(f"{destination_path}", "w") as f:
+        command = subprocess.run(["mysql2sqlite", path_to_dump], stdout=f)
+
+    if command.returncode != 0:
+        raise Exception(f"Error converting {path_to_dump} to SQLite compatible"
+                        f" at {destination_path}.")
+
+    logger.info(f"Converted at {destination_path}.")
+    return destination_path


### PR DESCRIPTION
Semi-last remaining piece of fully automating generation of
OpenStack invoices.
All that's left is to change coldfront data from using a
provided file to making a query, and to wrap it up using
a Dockerfile and put a cronjob.

---

Adds two command line arguments and functionality described
therein.

* `--download-sql-dump-from-s3 True`
  * When set to True, automatically downloads the SQL dump from
    S3 compatible storage. Supports configuring the input S3
    through environment variables S3_INPUT_ACCESS_KEY_ID,
    S3_INPUT_SECRET_ACCESS_KEY, S3_INPUT_BUCKET, and
    S3_OUTPUT_ENDPOINT_URL.
  * Will also automatically uncompress the file if it has been
    gzipped to save space.
* `--convert-sql-dump-file-from-s3`
  * Automatically converts the provided sql-dump-file (either
    through local path or download using the mysql2sqlite
    executable. (Must be present in path.)
* Adds some logging and configures it to print INFO level logs.