### PR TITLE
Add command line argument to upload or skip primary s3 location

### DIFF
--- a/src/openstack_billing_db/main.py
+++ b/src/openstack_billing_db/main.py
@@ -149,6 +149,13 @@ def main():
               " S3_OUTPUT_ENDPOINT_URL environment variables.")
     )
     parser.add_argument(
+        "--upload-to-primary-location",
+        default=True,
+        type=bool,
+        help=("When uploading to S3, upload both to primary and"
+              " archive location, or just archive location.")
+    )
+    parser.add_argument(
         "--output-file",
         default="/tmp/openstack_invoices.csv",
         help="Output path for invoice in CSV format."
@@ -198,6 +205,7 @@ def main():
         invoice_month=args.invoice_month,
         upload_to_s3=args.upload_to_s3,
         sql_dump_file=dump_file,
+        upload_to_primary_location=args.upload_to_primary_location,
     )
 
 


### PR DESCRIPTION
Motivation is that when we're running the invoicing to re-generate a previous invoice, we don't want it to overwrite the invoice in the primary location that was alreayd potentially used in successive steps of the pipeline.