### PR TITLE
Refactored SU Flavor logic

### DIFF
--- a/src/openstack_billing_db/billing.py
+++ b/src/openstack_billing_db/billing.py
@@ -105,6 +105,17 @@ def get_runtime_for_instance(
     return runtime
 
 
+def set_invoice_su_hours(invoice, service_unit_type, su_hours):
+    su_hour_attr = f"{service_unit_type}_su_hours"
+    if hasattr(invoice, su_hour_attr):
+        invoice.__setattr__(
+            su_hour_attr, invoice.__getattribute__(su_hour_attr) + su_hours
+        )
+    else:
+        raise Exception(f"Invalid flavor {service_unit_type}.")
+    return invoice
+
+
 def collect_invoice_data_from_openstack(
     database, billing_start, billing_end, rates, invoice_month=None
 ):
@@ -139,20 +150,7 @@ def collect_invoice_data_from_openstack(
                 su = i.service_units
                 su_hours = runtime_hours * su
 
-                if i.service_unit_type == "CPU":
-                    invoice.cpu_su_hours += su_hours
-                elif i.service_unit_type == "GPU A100SXM4":
-                    invoice.gpu_a100sxm4_su_hours += su_hours
-                elif i.service_unit_type == "GPU A100":
-                    invoice.gpu_a100_su_hours += su_hours
-                elif i.service_unit_type == "GPU V100":
-                    invoice.gpu_v100_su_hours += su_hours
-                elif i.service_unit_type == "GPU K80":
-                    invoice.gpu_k80_su_hours += su_hours
-                elif i.service_unit_type == "GPU A2":
-                    invoice.gpu_a2_su_hours += su_hours
-                else:
-                    raise Exception("Invalid flavor.")
+                invoice = set_invoice_su_hours(invoice, i.service_unit_type, su_hours)
 
         invoices.append(invoice)
     return invoices

--- a/src/openstack_billing_db/tests/unit/test_billing.py
+++ b/src/openstack_billing_db/tests/unit/test_billing.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime, timedelta
+import pytest
 
 from openstack_billing_db import billing
 from openstack_billing_db.model import Instance, InstanceEvent
@@ -27,3 +28,23 @@ def test_instance_simple_runtime():
     )
     assert r.total_seconds_running == (15 * DAY) - (DAY * 2)
     assert r.total_seconds_stopped == 0
+
+
+def test_billing_add_su_hours():
+    invoice = billing.ProjectInvoice(
+        project_name="foo",
+        project_id="foo",
+        pi="foo",
+        institution="foo",
+        invoice_interval="foo",
+        instances=[],
+        rates=None,
+    )
+    invoice = billing.set_invoice_su_hours(invoice, "cpu", 24)
+    assert invoice.cpu_su_hours == 24
+
+    invoice = billing.set_invoice_su_hours(invoice, "gpu_a100", 48)
+    assert invoice.gpu_a100_su_hours == 48
+
+    with pytest.raises(Exception) as e:
+        invoice = billing.set_invoice_su_hours(invoice, "gpu_fake", 72)

--- a/src/openstack_billing_db/tests/unit/test_instance.py
+++ b/src/openstack_billing_db/tests/unit/test_instance.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timedelta
 
-from openstack_billing_db.model import Instance, InstanceEvent
+from openstack_billing_db.model import Instance, InstanceEvent, Database
 from openstack_billing_db.tests.unit.utils import FLAVORS, MINUTE, HOUR, DAY, MONTH
 
 
@@ -158,3 +158,16 @@ def test_instance_no_delete_action_stopped_restarted():
     )
     assert r.total_seconds_running == (40 * MINUTE) + (40 * MINUTE)
     assert r.total_seconds_stopped == DAY - (40 * MINUTE)
+
+
+def test_instance_get_gpu_flavor():
+    test_pci_info = [("a100", "2"), ("a100-sxm4", "4")]
+    answers = [("gpu_a100", 2), ("gpu_a100sxm4", 4)]
+    for i in range(len(test_pci_info)):
+        pci_request = [
+            {"alias_name": test_pci_info[i][0], "count": test_pci_info[i][1]}
+        ]
+
+        su_type, count = Database._get_gpu_flavor_info(pci_request)
+        assert su_type == answers[i][0]
+        assert count == answers[i][1]

--- a/src/openstack_billing_db/tests/unit/utils.py
+++ b/src/openstack_billing_db/tests/unit/utils.py
@@ -1,6 +1,10 @@
 from openstack_billing_db import model
 
-FLAVORS = {1: model.Flavor(id=1, name="TestFlavor", vcpus=1, memory=4096, storage=10)}
+FLAVORS = {
+    1: model.Flavor(
+        id=1, service_unit_type="TestFlavor", vcpus=1, memory=4096, storage=10
+    )
+}
 
 MINUTE = 60
 HOUR = 60 * MINUTE


### PR DESCRIPTION
Closes #57. The Flavor object will no longer require an SU name. The SU type will be determined only from PCI requests.