### PR TITLE
Add support for not billing during outages

### DIFF
--- a/src/openstack_billing_db/main.py
+++ b/src/openstack_billing_db/main.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import argparse
 import logging
 
-from openstack_billing_db import billing, fetch
+from openstack_billing_db import billing, fetch, utils
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 def parse_time_argument(arg):
     if isinstance(arg, str):
-        return datetime.strptime(arg, "%Y-%m-%d")
+        return utils.parse_time_from_string(arg)
     return arg
 
 

--- a/src/openstack_billing_db/model.py
+++ b/src/openstack_billing_db/model.py
@@ -69,6 +69,12 @@ class InstanceRuntime(object):
     total_seconds_running: int = 0
     total_seconds_stopped: int = 0
 
+    def __sub__(self, other):
+        return InstanceRuntime(
+            self.total_seconds_running - other.total_seconds_running,
+            self.total_seconds_stopped - other.total_seconds_stopped,
+        )
+
 
 @dataclass
 class Instance(object):

--- a/src/openstack_billing_db/tests/unit/test_billing.py
+++ b/src/openstack_billing_db/tests/unit/test_billing.py
@@ -1,0 +1,29 @@
+import uuid
+from datetime import datetime, timedelta
+
+from openstack_billing_db import billing
+from openstack_billing_db.model import Instance, InstanceEvent
+from openstack_billing_db.tests.unit.utils import FLAVORS, MINUTE, HOUR, DAY, MONTH
+
+
+def test_instance_simple_runtime():
+    time = datetime(year=2000, month=1, day=1, hour=0, minute=0, second=0)
+    events = [
+        InstanceEvent(time=time, name="create", message=""),
+        InstanceEvent(time=time + timedelta(days=15), name="delete", message=""),
+    ]
+    i = Instance(
+        uuid=uuid.uuid4().hex, name=uuid.uuid4().hex, flavor=FLAVORS[1], events=events
+    )
+
+    r = billing.get_runtime_for_instance(
+        i,
+        datetime(year=2000, month=1, day=1, hour=0, minute=0, second=0),
+        datetime(year=2000, month=2, day=1, hour=0, minute=0, second=0),
+        excluded_intervals=[
+            ["2000-01-07", "2000-01-08"],
+            ["2000-01-01", "2000-01-02"],
+        ],
+    )
+    assert r.total_seconds_running == (15 * DAY) - (DAY * 2)
+    assert r.total_seconds_stopped == 0

--- a/src/openstack_billing_db/tests/unit/test_instance.py
+++ b/src/openstack_billing_db/tests/unit/test_instance.py
@@ -1,14 +1,8 @@
 import uuid
 from datetime import datetime, timedelta
 
-from openstack_billing_db.model import Instance, InstanceEvent, Flavor
-
-FLAVORS = {1: Flavor(id=1, name="TestFlavor", vcpus=1, memory=4096, storage=10)}
-
-MINUTE = 60
-HOUR = 60 * MINUTE
-DAY = HOUR * 24
-MONTH = 31 * DAY
+from openstack_billing_db.model import Instance, InstanceEvent
+from openstack_billing_db.tests.unit.utils import FLAVORS, MINUTE, HOUR, DAY, MONTH
 
 
 def test_instance_simple_runtime():
@@ -115,7 +109,7 @@ def test_instance_no_delete_action():
 
     r = i.get_runtime_during(
         datetime(year=1999, month=11, day=1, hour=0, minute=0, second=0),
-        datetime(year=2000, month=12, day=1, hour=0, minute=0, second=0),
+        datetime(year=1999, month=12, day=1, hour=0, minute=0, second=0),
     )
     assert r.total_seconds_running == 0
     assert r.total_seconds_stopped == 0

--- a/src/openstack_billing_db/tests/unit/test_instance_runtime.py
+++ b/src/openstack_billing_db/tests/unit/test_instance_runtime.py
@@ -1,0 +1,11 @@
+from openstack_billing_db.model import InstanceRuntime
+
+
+def test_instance_runtime_subtract():
+    a = InstanceRuntime(total_seconds_running=1000, total_seconds_stopped=1000)
+    b = InstanceRuntime(total_seconds_running=100, total_seconds_stopped=200)
+    c = a - b
+    assert c.total_seconds_running == 900
+    assert c.total_seconds_running == a.total_seconds_running - b.total_seconds_running
+    assert c.total_seconds_stopped == 800
+    assert c.total_seconds_stopped == a.total_seconds_stopped - b.total_seconds_stopped

--- a/src/openstack_billing_db/tests/unit/utils.py
+++ b/src/openstack_billing_db/tests/unit/utils.py
@@ -1,0 +1,8 @@
+from openstack_billing_db import model
+
+FLAVORS = {1: model.Flavor(id=1, name="TestFlavor", vcpus=1, memory=4096, storage=10)}
+
+MINUTE = 60
+HOUR = 60 * MINUTE
+DAY = HOUR * 24
+MONTH = 31 * DAY

--- a/src/openstack_billing_db/utils.py
+++ b/src/openstack_billing_db/utils.py
@@ -1,0 +1,5 @@
+from datetime import datetime
+
+
+def parse_time_from_string(time_str: str) -> datetime:
+    return datetime.strptime(time_str, "%Y-%m-%d")


### PR DESCRIPTION
Currently hardcoded values for the MGHPCC shutdown during May 2024.

Implemented via subtraction of the runtime of instances during the outage.