### PR TITLE
Extend outage list to support hours

### DIFF
--- a/src/openstack_billing_db/billing.py
+++ b/src/openstack_billing_db/billing.py
@@ -18,7 +18,10 @@ logger = logging.getLogger(__name__)
 # until we have formalized how to store them in the nerc-rates repo.
 # Usage during these intervals is subtracted from the usage during
 # the month.
-OUTAGES_FOR_MONTH = {"2024-05": [("2024-05-22", "2024-05-29")]}
+OUTAGES_FOR_MONTH = {
+    "2024-05": [("2024-05-22", "2024-05-29")],
+    "2025-01": [("2025-01-14 14:00:00", "2025-01-15 17:00:00")],
+}
 
 
 @dataclass()

--- a/src/openstack_billing_db/tests/unit/test_billing.py
+++ b/src/openstack_billing_db/tests/unit/test_billing.py
@@ -23,10 +23,10 @@ def test_instance_simple_runtime():
         datetime(year=2000, month=2, day=1, hour=0, minute=0, second=0),
         excluded_intervals=[
             ["2000-01-07", "2000-01-08"],
-            ["2000-01-01", "2000-01-02"],
+            ["2000-01-01 09:00:00", "2000-01-01 10:00:00"],
         ],
     )
-    assert r.total_seconds_running == (15 * DAY) - (DAY * 2)
+    assert r.total_seconds_running == (15 * DAY) - (DAY * 1) - (HOUR * 1)
     assert r.total_seconds_stopped == 0
 
 

--- a/src/openstack_billing_db/utils.py
+++ b/src/openstack_billing_db/utils.py
@@ -2,4 +2,4 @@ from datetime import datetime
 
 
 def parse_time_from_string(time_str: str) -> datetime:
-    return datetime.strptime(time_str, "%Y-%m-%d")
+    return datetime.fromisoformat(time_str)


### PR DESCRIPTION
The outages are in UTC.

Related https://github.com/CCI-MOC/invoicing/issues/53