### PR TITLE
temporary pin for incompatibility with new boto version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 git+https://github.com/CCI-MOC/nerc-rates#egg=nerc_rates
-boto3
+boto3 < 1.36
 dataclasses-json
 requests


### PR DESCRIPTION
It seems boto3 1.36 added default integrity checks, breaking uploads to backblaze. https://github.com/boto/boto3/issues/4401

resulting in the above error when uploading files
```
boto3.exceptions.S3UploadFailedError: Failed to upload /tmp/openstack_invoices.csv to nerc-invoicing/Invoices/2025-01/Service Invoices/NERC OpenStack 2025-01.csv: An error occurred (InvalidArgument) when calling the PutObject operation: Unsupported header 'x-amz-sdk-checksum-algorithm' received for this API call.
```

Temporary pinning boto3 to < 1.36 to resolve the issue until we have a proper fix in.