### PR TITLE
Explicitly request type when using `nerc_rates`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/CCI-MOC/nerc-rates#egg=nerc_rates
+git+https://github.com/CCI-MOC/nerc-rates@33701ed#egg=nerc_rates
 boto3 < 1.36
 dataclasses-json
 requests

--- a/src/openstack_billing_db/main.py
+++ b/src/openstack_billing_db/main.py
@@ -202,7 +202,7 @@ def main():
     if args.use_nerc_rates:
 
         def get_decimal_rate(rate_name):
-            return Decimal(nerc_repo_rates.get_value_at(rate_name, args.invoice_month))
+            return nerc_repo_rates.get_value_at(rate_name, args.invoice_month, Decimal)
 
         nerc_repo_rates = load_from_url()
         rates = billing.Rates(
@@ -214,9 +214,8 @@ def main():
             gpu_a2=get_decimal_rate("GPUA2 SU Rate"),
             include_stopped_runtime=(
                 nerc_repo_rates.get_value_at(
-                    "Charge for Stopped Instances", args.invoice_month
+                    "Charge for Stopped Instances", args.invoice_month, bool
                 )
-                == "True"
             ),
         )
     else:


### PR DESCRIPTION
With the recent update to `nerc_rates` [1] which added type enforcement and requires users of `nerc_rates` to explicitly declare the requested type, our script has been updated to request the appropriate types. This should reduce ambiguity in the values we fetch from nerc_rates

[1] https://github.com/CCI-MOC/nerc-rates/pull/22