### PR TITLE
Switch to Ruff from Black for formatting and linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,8 @@ repos:
       - id: detect-private-key
       - id: check-yaml
 
-  - repo: https://github.com/psf/black
-    rev: 24.4.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.10
     hooks:
-      - id: black
+      - id: ruff
+      - id: ruff-format

--- a/src/openstack_billing_db/billing.py
+++ b/src/openstack_billing_db/billing.py
@@ -3,7 +3,6 @@ import logging
 from datetime import datetime
 from dataclasses import dataclass
 from decimal import Decimal, ROUND_HALF_UP
-import json
 import math
 import os
 

--- a/src/openstack_billing_db/fetch.py
+++ b/src/openstack_billing_db/fetch.py
@@ -4,8 +4,6 @@ import os
 import subprocess
 
 import boto3
-import requests
-from requests.auth import HTTPBasicAuth
 
 logger = logging.getLogger(__name__)
 

--- a/src/openstack_billing_db/main.py
+++ b/src/openstack_billing_db/main.py
@@ -168,7 +168,7 @@ def main():
 
     if not dump_file:
         raise Exception(
-            "Must provide either --sql_dump_file" "or --download_dump_from_s3."
+            "Must provide either --sql_dump_fileor --download_dump_from_s3."
         )
 
     if args.use_nerc_rates:

--- a/src/openstack_billing_db/tests/unit/test_billing.py
+++ b/src/openstack_billing_db/tests/unit/test_billing.py
@@ -4,7 +4,7 @@ import pytest
 
 from openstack_billing_db import billing
 from openstack_billing_db.model import Instance, InstanceEvent
-from openstack_billing_db.tests.unit.utils import FLAVORS, MINUTE, HOUR, DAY, MONTH
+from openstack_billing_db.tests.unit.utils import FLAVORS, HOUR, DAY
 
 
 def test_instance_simple_runtime():
@@ -46,5 +46,5 @@ def test_billing_add_su_hours():
     invoice = billing.set_invoice_su_hours(invoice, "gpu_a100", 48)
     assert invoice.gpu_a100_su_hours == 48
 
-    with pytest.raises(Exception) as e:
+    with pytest.raises(Exception):
         invoice = billing.set_invoice_su_hours(invoice, "gpu_fake", 72)

--- a/src/openstack_billing_db/tests/unit/test_instance.py
+++ b/src/openstack_billing_db/tests/unit/test_instance.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, timedelta
 
 from openstack_billing_db.model import Instance, InstanceEvent, Database
-from openstack_billing_db.tests.unit.utils import FLAVORS, MINUTE, HOUR, DAY, MONTH
+from openstack_billing_db.tests.unit.utils import FLAVORS, MINUTE, DAY, MONTH
 
 
 def test_instance_simple_runtime():


### PR DESCRIPTION
Closes https://github.com/CCI-MOC/openstack-billing-from-db/issues/96. Switch from black to ruff-format as a pre-commit hook since it offers better performance and the groundwork for future linting enhancements like unused import detection and cleanup. 