### PR TITLE
Replacing hardcoded outages with dynamic loading from the nerc-rates repo.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/CCI-MOC/nerc-rates@33701ed#egg=nerc_rates
+git+https://github.com/CCI-MOC/nerc-rates@5569bba#egg=nerc_rates
 boto3 < 1.36
 dataclasses-json
 requests

--- a/src/openstack_billing_db/tests/unit/test_billing.py
+++ b/src/openstack_billing_db/tests/unit/test_billing.py
@@ -22,8 +22,14 @@ def test_instance_simple_runtime():
         datetime(year=2000, month=1, day=1, hour=0, minute=0, second=0),
         datetime(year=2000, month=2, day=1, hour=0, minute=0, second=0),
         excluded_intervals=[
-            ["2000-01-07", "2000-01-08"],
-            ["2000-01-01 09:00:00", "2000-01-01 10:00:00"],
+            (
+                datetime(year=2000, month=1, day=7, hour=0, minute=0, second=0),
+                datetime(year=2000, month=1, day=8, hour=0, minute=0, second=0),
+            ),
+            (
+                datetime(year=2000, month=1, day=1, hour=9, minute=0, second=0),
+                datetime(year=2000, month=1, day=1, hour=10, minute=0, second=0),
+            ),
         ],
     )
     assert r.total_seconds_running == (15 * DAY) - (DAY * 1) - (HOUR * 1)


### PR DESCRIPTION
Closes #126

Replaced hardcoded outage dates with dynamic loading from the nerc-rates repository.

Removed hardcoded dict from `billing.py`

Updated test to use datetime tuples instead of strings

Updated `requirements.txt` to latest nerc-rates version that includes the up-to-date models