### PR TITLE
Updated requirements to pin boto3 version to 1.42.6 or higher

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 git+https://github.com/CCI-MOC/nerc-rates@5569bba#egg=nerc_rates
-boto3 < 1.36
+boto3>=1.42.6,<2.0
 dataclasses-json
 requests


### PR DESCRIPTION
It seems like the Backblaze team has updated their S3 APIs to accept the new checksum algorithm header and thus doesn't produce the errors that were previously described.

Closes #128